### PR TITLE
Añadir navegación entre desafíos

### DIFF
--- a/desafios/01/index.html
+++ b/desafios/01/index.html
@@ -27,6 +27,12 @@
   </code>
 </pre>
       </article>
+      <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/02/">
+        <span>Día 2</span>
+        <svg height="16" viewBox="0 0 320 512">
+          <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+        </svg>
+      </a>
     </div>
     <div class="view">
       <h2>Vista previa</h2>

--- a/desafios/01/style.css
+++ b/desafios/01/style.css
@@ -39,3 +39,20 @@ h2, h3 {
   align-items: center;
   padding: 1rem;
 }
+
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/02/index.html
+++ b/desafios/02/index.html
@@ -35,6 +35,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/01/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 1</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/03/">
+          <span>Día 3</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <h1>Roadmap Frontend Developer</h1>

--- a/desafios/02/style.css
+++ b/desafios/02/style.css
@@ -38,3 +38,28 @@ h1, h2, h3 {
   gap: 1rem;
   padding: 1rem;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/03/index.html
+++ b/desafios/03/index.html
@@ -31,6 +31,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/02/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 2</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/04/">
+          <span>Día 4</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <p>Esta sería la solución para el reto del día 3 del <em><a href="https://lenguajehtml.com/challenge/">"HTML 30-day challenge"</a></em> creado por ManzDev.</p>

--- a/desafios/03/style.css
+++ b/desafios/03/style.css
@@ -42,3 +42,28 @@ h1, h2, h3 {
 .view ul {
   margin-left: 5%;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/04/index.html
+++ b/desafios/04/index.html
@@ -64,6 +64,20 @@
           <li><mark>Día 30: Document checking completed. No errors or warnings to show.</mark></li>
         </ul>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/03/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 3</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/05/">
+          <span>Día 5</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <h2>Vista previa</h2>

--- a/desafios/04/style.css
+++ b/desafios/04/style.css
@@ -74,3 +74,28 @@ code {
   justify-content: center;
   padding: 1rem;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/05/index.html
+++ b/desafios/05/index.html
@@ -30,6 +30,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/04/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 4</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/06/">
+          <span>Día 6</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <h2>Vista previa</h2>

--- a/desafios/05/style.css
+++ b/desafios/05/style.css
@@ -39,3 +39,28 @@ h2, h3 {
   align-items: center;
   padding: 1rem;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/06/index.html
+++ b/desafios/06/index.html
@@ -41,6 +41,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/05/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 5</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/07/">
+          <span>Día 7</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <details open name="dia-6">

--- a/desafios/06/style.css
+++ b/desafios/06/style.css
@@ -10,6 +10,10 @@ html {
   font-size: 1.2rem;
 }
 
+body {
+  overflow-x: hidden;
+}
+
 h2, h3 {
   margin-bottom: 0.5rem;
 }
@@ -36,4 +40,29 @@ h2, h3 {
   display: flex;
   flex-direction: column;
   padding: 1rem;
+}
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
 }

--- a/desafios/07/index.html
+++ b/desafios/07/index.html
@@ -26,6 +26,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/06/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 6</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/08/">
+          <span>Día 8</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <picture>

--- a/desafios/07/style.css
+++ b/desafios/07/style.css
@@ -38,6 +38,30 @@ h2, h3 {
   padding: 1rem;
 }
 
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}
 .view img {
   width: 100%;
 }

--- a/desafios/08/index.html
+++ b/desafios/08/index.html
@@ -44,6 +44,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/07/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 7</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/09/">
+          <span>Día 9</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <p>Lorem, ipsum dolor sit amet consectetur <mark class="color">adipisicing elit.</mark> Ipsam aperiam, quod

--- a/desafios/08/style.css
+++ b/desafios/08/style.css
@@ -10,6 +10,10 @@ html {
   font-size: 1.2rem;
 }
 
+body {
+  overflow-x: hidden;
+}
+
 h2, h3 {
   margin-bottom: 0.5rem;
 }
@@ -44,4 +48,29 @@ h2, h3 {
 
 .color:last-of-type {
   background-color: blueviolet;
+}
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
 }

--- a/desafios/09/index.html
+++ b/desafios/09/index.html
@@ -74,6 +74,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/08/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 8</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/10/">
+          <span>Día 10</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <div class="container">

--- a/desafios/09/style.css
+++ b/desafios/09/style.css
@@ -12,6 +12,10 @@ html {
   font-size: 1.2rem;
 }
 
+body {
+  overflow-x: hidden;
+}
+
 h2, h3 {
   margin-bottom: 0.5rem;
 }
@@ -71,4 +75,29 @@ h2, h3 {
 .container ol {
   padding-left: 8%;
   color: #2c2c2c;
+}
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
 }

--- a/desafios/10/index.html
+++ b/desafios/10/index.html
@@ -118,6 +118,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/09/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 9</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/11/">
+          <span>Día 11</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <main>

--- a/desafios/10/style.css
+++ b/desafios/10/style.css
@@ -11,7 +11,7 @@ html {
 }
 
 body {
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 h2, h3 {
@@ -99,4 +99,29 @@ h2, h3 {
 .controls button:hover {
   background-color: #0056b3;
   font-size: 1.2rem;
+}
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
 }

--- a/desafios/11/index.html
+++ b/desafios/11/index.html
@@ -91,6 +91,20 @@
 </pre>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/10/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 10</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/12/">
+          <span>Día 12</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <main>

--- a/desafios/11/style.css
+++ b/desafios/11/style.css
@@ -11,7 +11,7 @@ html {
 }
 
 body {
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 h2, h3 {
@@ -74,4 +74,29 @@ section {
 .header {
   text-align: center;
   margin-bottom: 1rem;
+}
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
 }

--- a/desafios/12/index.html
+++ b/desafios/12/index.html
@@ -33,6 +33,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/11/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 11</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/13/">
+          <span>Día 13</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <input type="range" name="slider" id="slider" value="1" min="1" max="50" step="1" onInput="this.nextElementSibling.value = this.value">

--- a/desafios/12/style.css
+++ b/desafios/12/style.css
@@ -41,3 +41,28 @@ h2, h3 {
   flex-direction: column;
   padding: 1rem;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/13/index.html
+++ b/desafios/13/index.html
@@ -25,6 +25,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/12/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 12</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/14/">
+          <span>Día 14</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <p>64/100 tickets vendidos</p>

--- a/desafios/13/style.css
+++ b/desafios/13/style.css
@@ -41,3 +41,28 @@ h2, h3 {
   flex-direction: column;
   padding: 1rem;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/14/index.html
+++ b/desafios/14/index.html
@@ -44,6 +44,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/13/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 13</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/15/">
+          <span>Día 15</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <pre>

--- a/desafios/14/style.css
+++ b/desafios/14/style.css
@@ -11,7 +11,7 @@ html {
 }
 
 body {
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 h2, h3 {
@@ -40,4 +40,29 @@ h2, h3 {
   display: flex;
   flex-direction: column;
   padding: 1rem;
+}
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
 }

--- a/desafios/15/index.html
+++ b/desafios/15/index.html
@@ -30,6 +30,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/14/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 14</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/16/">
+          <span>Día 16</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <video src="../../assets/video/waves-loop.mp4" poster="../../assets/img/play.svg" width="640px" height="360px" loop controls></video>

--- a/desafios/15/style.css
+++ b/desafios/15/style.css
@@ -43,3 +43,28 @@ h2, h3 {
   justify-content: center;
   padding: 1rem;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/16/index.html
+++ b/desafios/16/index.html
@@ -55,6 +55,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/15/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 15</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/17/">
+          <span>Día 17</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <div class="container">

--- a/desafios/16/style.css
+++ b/desafios/16/style.css
@@ -11,7 +11,7 @@ html {
 }
 
 body {
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 h2, h3 {
@@ -67,4 +67,29 @@ kbd {
 
 kbd:hover {
   background-color: #aeaeae;
+}
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
 }

--- a/desafios/17/index.html
+++ b/desafios/17/index.html
@@ -112,6 +112,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/16/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 16</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/18/">
+          <span>Día 18</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <div class="container">

--- a/desafios/17/style.css
+++ b/desafios/17/style.css
@@ -11,7 +11,7 @@ html {
 }
 
 body {
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 h2, h3 {
@@ -107,4 +107,29 @@ footer a {
 footer a:hover {
   text-decoration: none;
   scale: 115%;
+}
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
 }

--- a/desafios/18/index.html
+++ b/desafios/18/index.html
@@ -89,6 +89,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/17/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 17</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/19/">
+          <span>Día 19</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <article>

--- a/desafios/18/style.css
+++ b/desafios/18/style.css
@@ -59,3 +59,28 @@ h2, h3 {
 .view p {
   text-wrap: pretty;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/19/index.html
+++ b/desafios/19/index.html
@@ -129,6 +129,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/18/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 18</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/20/">
+          <span>Día 20</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <table>

--- a/desafios/19/style.css
+++ b/desafios/19/style.css
@@ -58,3 +58,28 @@ table td {
 table td:last-child {
   background-color: black;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/20/index.html
+++ b/desafios/20/index.html
@@ -68,6 +68,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/19/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 19</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/21/">
+          <span>Día 21</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <form action="/enviar" method="post">

--- a/desafios/20/style.css
+++ b/desafios/20/style.css
@@ -68,3 +68,28 @@ textarea {
   border-radius: 4px;
   box-shadow: black 0 0 4px;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/21/index.html
+++ b/desafios/21/index.html
@@ -54,6 +54,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/20/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 20</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/22/">
+          <span>Día 22</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <p>Desarrollo de software</p>

--- a/desafios/21/style.css
+++ b/desafios/21/style.css
@@ -55,3 +55,28 @@ select {
   border: none;
   box-shadow: black 0 0 4px;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/22/index.html
+++ b/desafios/22/index.html
@@ -48,6 +48,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/21/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 21</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/23/">
+          <span>Día 23</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <p>Desarrollo de software</p>

--- a/desafios/22/style.css
+++ b/desafios/22/style.css
@@ -55,3 +55,28 @@ input {
   border: none;
   box-shadow: black 0 0 4px;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/23/index.html
+++ b/desafios/23/index.html
@@ -38,6 +38,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/22/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 22</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/24/">
+          <span>Día 24</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <form action="/send" method="get">

--- a/desafios/23/style.css
+++ b/desafios/23/style.css
@@ -54,3 +54,28 @@ input {
   border: none;
   box-shadow: black 0 0 4px;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/24/index.html
+++ b/desafios/24/index.html
@@ -39,6 +39,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/23/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 23</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/25/">
+          <span>Día 25</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <form action="/send">

--- a/desafios/24/style.css
+++ b/desafios/24/style.css
@@ -55,3 +55,28 @@ input {
   box-shadow: black 0 0 4px;
 
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/25/index.html
+++ b/desafios/25/index.html
@@ -37,6 +37,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/24/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 24</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/26/">
+          <span>Día 26</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <img src="../../assets/img/avatar.webp" alt="Avatar odraciRdev">

--- a/desafios/25/style.css
+++ b/desafios/25/style.css
@@ -52,3 +52,28 @@ img {
   width: 98%;
   margin-bottom: 1rem;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/26/index.html
+++ b/desafios/26/index.html
@@ -67,6 +67,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/25/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 25</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/27/">
+          <span>Día 27</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <button popovertarget="mensaje" popovertargetaction="toggle">Mostrar mensaje</button>

--- a/desafios/26/style.css
+++ b/desafios/26/style.css
@@ -78,3 +78,28 @@ button {
   align-items: center;
   margin: auto;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/27/index.html
+++ b/desafios/27/index.html
@@ -69,6 +69,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/26/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 26</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/28/">
+          <span>Día 28</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <h2>Vista previa</h2>

--- a/desafios/27/style.css
+++ b/desafios/27/style.css
@@ -10,6 +10,10 @@ html {
   font-size: 1.2rem;
 }
 
+body {
+  overflow-x: hidden;
+}
+
 h2, h3 {
   margin-bottom: 0.5rem;
 }
@@ -38,4 +42,29 @@ h2, h3 {
   justify-content: center;
   align-items: center;
   padding: 1rem;
+}
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
 }

--- a/desafios/28/index.html
+++ b/desafios/28/index.html
@@ -40,6 +40,20 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/27/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 27</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/29/">
+          <span>Día 29</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <dialog id="alerta">

--- a/desafios/28/style.css
+++ b/desafios/28/style.css
@@ -47,3 +47,28 @@ h2, h3 {
   align-items: center;
   padding: 1rem;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/29/index.html
+++ b/desafios/29/index.html
@@ -71,6 +71,20 @@ tab3.addEventListener("click", function() {
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/28/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 28</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/desafios/30/">
+          <span>Día 30</span>
+          <svg height="16" viewBox="0 0 320 512">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="view">
       <div class="container">

--- a/desafios/29/style.css
+++ b/desafios/29/style.css
@@ -47,3 +47,28 @@ h2, h3 {
   align-items: center;
   padding: 1rem;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/desafios/30/index.html
+++ b/desafios/30/index.html
@@ -44,6 +44,17 @@
   </code>
 </pre>
       </article>
+      <div>
+        <a class="btn-prev" href="https://odracirdev.github.io/challengeHTML/desafios/29/">
+          <svg height="16" viewBox="0 0 320 512" style="scale: -1">
+            <path fill="currentColor" d="M311 233c12 13 12 33 0 46L119 471a32 32 0 0 1-46-46l170-169L73 87a32 32 0 0 1 46-46l192 192z"/>
+          </svg>
+          <span>Día 29</span>
+        </a>
+        <a class="btn-next" href="https://odracirdev.github.io/challengeHTML/">
+          <span>Inicio</span>
+        </a>
+      </div>
     </div>
     <div class="view">
       <button id="confetti">¡Libera el confetti!</button>

--- a/desafios/30/style.css
+++ b/desafios/30/style.css
@@ -64,3 +64,28 @@ canvas {
   height: 100%;
   z-index: 1;
 }
+
+div:has(> .btn-prev) {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-prev,
+.btn-next {
+  background-color: #2d2d2d;
+  color: #fff;
+  padding: 14px 18px;
+  text-decoration: none;
+  width: max-content;
+  display: inline-flex;
+  gap: 6px;
+  align-items: end;
+  line-height: 95%;
+  transition: background-color 300ms ease;
+}
+
+.btn-prev:hover,
+.btn-next:hover {
+  background-color: #383838;
+}

--- a/index.html
+++ b/index.html
@@ -31,123 +31,123 @@
     <section class="challenges-container">
       <div class="challenge done">
         <h2>Día 1</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/01/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/01/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 2</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/02/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/02/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 3</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/03/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/03/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 4</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/04/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/04/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 5</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/05/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/05/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 6</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/06/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/06/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 7</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/07/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/07/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 8</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/08/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/08/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 9</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/09/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/09/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 10</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/10/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/10/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 11</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/11/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/11/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 12</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/12/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/12/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 13</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/13/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/13/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 14</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/14/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/14/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 15</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/15/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/15/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 16</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/16/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/16/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 17</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/17/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/17/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 18</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/18/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/18/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 19</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/19/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/19/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 20</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/20/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/20/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 21</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/21/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/21/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 22</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/22/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/22/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 23</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/23/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/23/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 24</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/24/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/24/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 25</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/25/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/25/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 26</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/26/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/26/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 27</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/27/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/27/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 28</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/28/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/28/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 29</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/29/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/29/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
       <div class="challenge done">
         <h2>Día 30</h2>
-        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/30/" target="_blank"><span class="material-symbols-outlined">captive_portal</span></a></p>
+        <p><a href="https://odracirdev.github.io/challengeHTML/desafios/30/"><span class="material-symbols-outlined">captive_portal</span></a></p>
       </div>
     </section>
     <footer>


### PR DESCRIPTION
Esta PR arregla #4.

Vista previa de los cambios añadidos:

https://github.com/odracirdev/challengeHTML/assets/38303370/06bd7c6b-adfb-482f-9000-ca099f0bdcc1

Otros cambios:
- Se eliminó el atributo `target="_blank"` para evitar que cada desafío se abra en una nueva pestaña.